### PR TITLE
modified grep so daX are added to list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
 
+# Version 1.1 (2019-07-09)
+  * Add detection of "da" prefixed devices (Thanks to @bilditup1)
+
 # Version 1.0 (2019-07-04)
   * Initial release

--- a/spindown_timer.sh
+++ b/spindown_timer.sh
@@ -4,7 +4,7 @@
 # FreeNAS HDD Spindown Timer
 # Monitors drive I/O and forces HDD spindown after a given idle period.
 #
-# Version: 1.0
+# Version: 1.1
 #
 # See: https://github.com/ngandrass/freenas-spindown-timer
 #

--- a/spindown_timer.sh
+++ b/spindown_timer.sh
@@ -99,7 +99,7 @@ function log_verbose() {
 # Drives listed in $IGNORE_DRIVES will be excluded.
 ##
 function get_drives() {
-    local DRIVES=`iostat -x | grep -E '(ada|da)' | awk '{printf $1 " "}'`
+    local DRIVES=`iostat -x | grep -E '^(ada|da)' | awk '{printf $1 " "}'`
     DRIVES=" ${DRIVES} " # Space padding must be kept for pattern matching
 
     # Remove ignored drives

--- a/spindown_timer.sh
+++ b/spindown_timer.sh
@@ -94,12 +94,12 @@ function log_verbose() {
 }
 
 ##
-# Retrieves a list of all connected drives (devices prefixed with "ada").
+# Retrieves a list of all connected drives (devices prefixed with "ada|da").
 #
 # Drives listed in $IGNORE_DRIVES will be excluded.
 ##
 function get_drives() {
-    local DRIVES=`iostat -x | grep 'ada' | awk '{printf $1 " "}'`
+    local DRIVES=`iostat -x | grep -E '(ada|da)' | awk '{printf $1 " "}'`
     DRIVES=" ${DRIVES} " # Space padding must be kept for pattern matching
 
     # Remove ignored drives


### PR DESCRIPTION
With current script on my system, only drives that use the built-in chipsets (Intel et al) get the nomenclature adaX. The rest of the drives, on LSI HBAs, have the nomenclature daX and thus were omitted by current script.  Made a minor change that rectifies this. 