### PR TITLE
changed camcontrol syntax for LSI compatibility

### DIFF
--- a/spindown_timer.sh
+++ b/spindown_timer.sh
@@ -141,7 +141,7 @@ function get_idle_drives() {
 #   $1 Device identifier of the drive
 ##
 function drive_is_spinning() {
-    echo "`camcontrol cmd $1 -a 'E5 00 00 00 00 00 00 00 00 00 00 00' -r - | cut -d ' ' -f 10 | sed 's/FF/1/' | sed 's/00/0/'`"
+    if [[ -z $(camcontrol epc $1 -c status -P | grep 'S') ]]; then echo 1; else echo 0; fi
 }
 
 ##

--- a/spindown_timer.sh
+++ b/spindown_timer.sh
@@ -141,7 +141,7 @@ function get_idle_drives() {
 #   $1 Device identifier of the drive
 ##
 function drive_is_spinning() {
-    if [[ -z $(camcontrol epc $1 -c status -P | grep 'S') ]]; then echo 1; else echo 0; fi
+    if [[ -z $(camcontrol epc $1 -c status -P | grep 'Standby') ]]; then echo 1; else echo 0; fi
 }
 
 ##


### PR DESCRIPTION
`camcontrol cmd` doesn't work with LSI HBAs. Or least it doesn't work with mine (2008 and 2308). Instead, it spits out the following error:

> camcontrol: error sending command

Therefore the script doesn't work for drives connected to them, since drive_is_spinning never returns 1.

My solution is to use epc instead, hence this patch.

On my system, no issues doing this - works for both drives on HBA and drives on mobo's chipsets. My guess is further testing on other systems might be a good idea though.

See here for reference: 
https://www.freebsd.org/cgi/man.cgi?query=camcontrol&apropos=0&sektion=8&manpath=FreeBSD+11.2-RELEASE&arch=default&format=html



> `epc`
>> Issue ATA Extended Power Conditions (EPC) feature set com-
		 mands.	 This only works on ATA	protocol drives, and will not
		 work on SCSI protocol drives.	It will	work on	SATA drives
		 behind	a SCSI to ATA translation layer	(SAT).	It may be
		 helpful to read the ATA Command Set - 4 (ACS-4) description
		 of the	Extended Power Conditions feature set, available at
		 t13.org, to understand	the details of this particular
		 camcontrol subcommand.

>> `-c`
>>> Specify the epc subcommand
>>>> `status`
>>>>>Get the current status of several parameters
				  related to the Extended Power	Condition
				  (EPC)	feature	set, including whether APM and
				  EPC are supported and	enabled, whether Low
				  Power	Standby	is supported, whether setting
				  the EPC power	source is supported, whether
				  Low Power Standby is supported and the cur-
				  rent power condition.
>>>>>>`-P`  
>>>>>>> Only report the current power condi-
				     tion.  Some drives will exit their cur-
				       rent power condition if a command other
				       than the	ATA CHECK POWER	MODE command
				       is received.  If	this flag is speci-
				       fied, camcontrol	will only issue	the
				       ATA CHECK POWER MODE command to the
				       drive.


