### PR TITLE
add timeout to shut down system if all drives are idle

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ and `FreeNAS-11.2-U7`.
 
 ## Usage
 ```
-Usage: spindown_timer.sh [-h] [-q] [-v] [-d] [-m] [-t TIMEOUT] [-p POLL_TIME] [-i DRIVE]
+Usage: spindown_timer.sh [-h] [-q] [-v] [-d] [-m] [-t TIMEOUT] [-p POLL_TIME] [-i DRIVE]  [-s TIMEOUT]
 
 Monitors drive I/O and forces HDD spindown after a given idle period.
 Resistant to S.M.A.R.T. reads.
@@ -53,6 +53,8 @@ Options:
                  drive and never issue a spindown command for it.
                  In manual mode [-m]: Only monitor the specified drives.
                  Multiple drives can be given by repeating the -i switch.
+  -s TIMEOUT   : Shutdown timeout, if no drive is active for TIMEOUT seconds, 
+                 the system will be shut down 
   -h           : Print this help message.
 ```
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,15 @@ It is also possible to run multiple instances of the script with independent `TI
 
 To verify the correct drive selection, a list of all drives that are being monitored by the running script instance is printed directly after starting the script (except in quiet mode [-q]).
 
+### Automatic system shutdown [-s TIMEOUT]
+When a timeout is given via the `-s` argument, the system will be shut down by
+the script if all monitored drives were idle for the specified number of
+seconds. This feature can be used to automatically shut down a system that might
+be woken via wake-on-LAN (WOL) later on.
+
+Setting `TIMEOUT` to 0 results in no shutdown.
+
+
 ## Warning
 Heavily spinning disk drives up and down increases disk wear. Before deploying this script, consider carefully which of your drives are frequently accessed and should therefore not be aggressively spun down. A good rule of thumb is to keep disk spin-ups below 5 per 24 hours. You can keep an eye on your drives `Load_Cycle_Count` and `Start_Stop_Count` S.M.A.R.T values to monitor the number of performed spin-ups.
 

--- a/spindown_timer.sh
+++ b/spindown_timer.sh
@@ -4,14 +4,14 @@
 # FreeNAS HDD Spindown Timer
 # Monitors drive I/O and forces HDD spindown after a given idle period.
 #
-# Version: 1.3.1
+# Version: 1.3.2
 #
 # See: https://github.com/ngandrass/freenas-spindown-timer
 #
 #
 # MIT License
 # 
-# Copyright (c) 2019 Niels Gandraß
+# Copyright (c) 2022 Niels Gandraß
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/spindown_timer.sh
+++ b/spindown_timer.sh
@@ -184,7 +184,7 @@ function get_idle_drives() {
 # Arguments:
 #   $1 list of idle drives as returned by get_idle_drives()
 ##
-function all_drives_idle() {
+function all_drives_are_idle() {
     local DRIVES=" $(get_drives) "
     
     for drive in ${DRIVES}; do
@@ -306,7 +306,7 @@ function main() {
         log_verbose "$(get_drive_timeouts)"
         
         if [ ${SHUTDOWN_TIMEOUT} -gt 0 ]; then
-            if all_drives_idle "${IDLE_DRIVES}"; then
+            if all_drives_are_idle "${IDLE_DRIVES}"; then
                 SHUTDOWN_COUNTER=$((SHUTDOWN_COUNTER - POLL_TIME))
                 if [[ ! ${SHUTDOWN_COUNTER} -gt 0 ]]; then
                     log_verbose "Shutting down system"

--- a/spindown_timer.sh
+++ b/spindown_timer.sh
@@ -273,7 +273,7 @@ function main() {
     log "I/O check sample period: ${POLL_TIME} sec"
     
     if [ ${SHUTDOWN_TIMEOUT} -gt 0 ]; then
-        log "Shuting down system after ${SHUTDOWN_TIMEOUT} seconds of inactivity"
+        log "System will be shut down after ${SHUTDOWN_TIMEOUT} seconds of inactivity"
     fi
 
     # Init timeout counters for all monitored drives
@@ -315,7 +315,7 @@ function main() {
             else
                 SHUTDOWN_COUNTER=${SHUTDOWN_TIMEOUT}
             fi
-            log_verbose "Shutdwon timeout: ${SHUTDOWN_COUNTER}"
+            log_verbose "Shutdown timeout: ${SHUTDOWN_COUNTER}"
         fi
 
     done


### PR DESCRIPTION
As written in the title, this adds a new option to set a shut down timeout. If all monitored drives are idle for that time, the nas will shut down.

I thought this might be interesting for others as well, so you can merge it if you want.